### PR TITLE
Add spatial db query

### DIFF
--- a/app/api/search/[coordinates]/route.ts
+++ b/app/api/search/[coordinates]/route.ts
@@ -1,0 +1,17 @@
+import prisma from "@/lib/prisma"
+import { Prisma } from "@prisma/client"
+
+export async function GET(req, { params }) {
+  const { coordinates } = params
+  // TODO check that this doesn't need more sanitizing
+  const lineStringCoords = Prisma.raw(decodeURI(coordinates))
+
+  const sql = Prisma.sql`SELECT name, properties
+         FROM buildings WHERE
+          ST_Intersects(ST_Transform(geom, 3857),
+          ST_Transform(ST_Polygon('LINESTRING(${lineStringCoords})'::geometry, 4326), 3857))`
+
+  const buildings = await prisma.$queryRaw(sql)
+
+  return Response.json({ buildings })
+}

--- a/components/map/map.tsx
+++ b/components/map/map.tsx
@@ -12,6 +12,7 @@ import { ScenarioControl } from "./scenario-control"
 import { useStore } from "../../app/lib/store"
 import { round, difference } from "lodash-es"
 import { DrawControlPane } from "./draw-control-pane"
+import { globalVariables } from "../../global-config"
 
 type MapViewProps = {
   children?: ReactNode
@@ -28,6 +29,18 @@ const MapView = ({ id, center, zoom, children }: MapViewProps) => {
   const { setAoi, aoi, isDrawing, setIsDrawing } = useStore()
   const [selectedFeatureIds, setSelectedFeatureIds] = useState([])
   const { setTotalSelectedFeatures } = useStore()
+
+  const getDbIntersectingFeatures = async coordinates => {
+    const linestring = encodeURI(
+      coordinates.map(pair => pair.join(" ")).join(",")
+    )
+
+    const promise2 = await fetch(
+      `${globalVariables.basePath}/api/search/${linestring}`
+    )
+    const buildings = await promise2.json()
+    console.log({ buildings })
+  }
 
   useEffect(() => {
     if (selectedFeatureIds && !aoi.feature) {
@@ -53,6 +66,8 @@ const MapView = ({ id, center, zoom, children }: MapViewProps) => {
     )
 
     updateIntersectingFeatures(intersectingFeatures)
+
+    getDbIntersectingFeatures(aoi.feature.geometry.coordinates[0])
   }, [aoi.feature, aoi.bbox, map, roundedZoom])
 
   const updateIntersectingFeatures = featureIdsToUpdate => {

--- a/components/side-pane.tsx
+++ b/components/side-pane.tsx
@@ -40,26 +40,10 @@ export const SidePane: React.FC<Props> = ({ src, study_id }) => {
       <ThemeSelector />
       <div className="self-stretch grow shrink basis-0 flex-col justify-start items-start gap-6 flex">
         <div className="self-stretch h-[0px] origin-top-left rotate-180 border border-black"></div>
-
         <div className="self-stretch h-[68px] flex-col justify-start items-start gap-3 flex">
-          <div className="text-sky-800 text-xl font-medium font-['Inter'] leading-7">
-            Number of selected Buildings
-          </div>
-          <div className="self-stretch justify-start items-end gap-3 inline-flex">
-            <div>
-              {/* <span className="text-black text-xl font-normal font-['Inter'] leading-7">
-                €
-              </span> */}
-              <span className="text-black text-xl font-semibold font-['Inter'] leading-7">
-                0
-              </span>
-            </div>
-          </div>
+          Number of Features in Spatial DB Query
         </div>
         <div className="self-stretch h-[0px] origin-top-left rotate-180 border border-black"></div>
-      </div>
-      <div className="justify-start items-center gap-6 inline-flex">
-        <div className="justify-start items-start gap-3 flex"></div>
       </div>
     </div>
   )


### PR DESCRIPTION
## What I'm adding
I'm adding a spatial query to the Vercel database. After drawing an area of interest (aoi) on the map, I take the polygon of that area and send it to the postgres database. The database responds with all features that intersect with this query. We will want to limit this query only to the most necessary information (i.e. feature id, name, selected theme, selected scenario). Right now all this is stored in the properties json object and it is not easy to make directed small queries like this. 

Here is what the process and the response looks like in the frontend. I have highlighted the value of features selected in the frontend through query rendered features and on the right side the database spatial query response. 
<img width="1436" alt="spatial_query" src="https://github.com/developmentseed/tecnico-energy-app/assets/31222040/d8cf410e-95e7-461e-88bd-3bf48f632b92">

It would be great to talk this over @emmalu and @alukach to figure out the best database schema to support this type of query. 
