### PR TITLE
Use pre-aggregated max for tile route

### DIFF
--- a/app/api/tiles/[study_slug]/[scenario_slug]/[metrics_field]/[z]/[x]/[y]/route.ts
+++ b/app/api/tiles/[study_slug]/[scenario_slug]/[metrics_field]/[z]/[x]/[y]/route.ts
@@ -10,12 +10,7 @@ export async function GET(req: NextRequest, { params }: { params: Params }) {
   } catch (e) {
     return new Response((e as Error).message, { status: 400 })
   }
-  const sql = tile.asSql(
-    "geometries",
-    "geom",
-    "scenario_metrics",
-    "scenario_metrics_total"
-  )
+  const sql = tile.asSql("geometries", "geom", "scenario_metrics_total")
   const [{ st_asmvt }] = await prisma.$queryRaw<{ st_asmvt: Buffer }[]>(sql)
 
   return new Response(


### PR DESCRIPTION
## What I'm changing

I'm making use of the pre-aggregated scenario_metrics_table in the tile route to save on extra computation in the query. 