### PR TITLE
Fix missing municipal totals

### DIFF
--- a/app/api/search/[study_slug]/[scenario_slug]/[metrics_field]/route.ts
+++ b/app/api/search/[study_slug]/[scenario_slug]/[metrics_field]/route.ts
@@ -6,6 +6,7 @@ export async function GET(req: NextRequest, { params }: { params: Params }) {
   const { study_slug, metrics_field, scenario_slug } = params
   const coordinates = req?.nextUrl?.searchParams.get("coordinates")!
   // get all features if we have no aoi
+  // only return the aggregated values from metrics with LIMIT 1
   if (coordinates == "null") {
     const search = await prisma.$queryRaw`
       SELECT 
@@ -20,6 +21,8 @@ export async function GET(req: NextRequest, { params }: { params: Params }) {
           ((g.study_slug = ${study_slug} AND m.scenario_slug IS NULL AND ${scenario_slug} = 'baseline') OR 
           (g.study_slug = ${study_slug} AND m.scenario_slug IS NOT NULL AND m.scenario_slug = ${scenario_slug}))
       GROUP BY m.id
+      ORDER BY data_total asc
+      LIMIT 1
     `
     return Response.json({ search })
   }


### PR DESCRIPTION
## What I'm changing

The search query was returning two results for the aggregation query (one for the geometries data, which is always null and one for the metrics which we want). I am limiting the results to only the metrics data.

<img width="1508" alt="Screenshot 2024-04-18 at 8 57 53 AM" src="https://github.com/developmentseed/tecnico-energy-app/assets/31222040/c6bc7e35-5348-49b1-bccb-6a393ba22885">
