### PR TITLE
Map legend should be based on max value, not total (ie sum) value

### DIFF
--- a/components/map/color-legend.tsx
+++ b/components/map/color-legend.tsx
@@ -8,7 +8,7 @@ export const ColorLegend: React.FC = () => {
     selectedStudy?.selectedTheme?.selectedScenario?.selectedCategory?.label
   const summaryUnit = selectedStudy.summary.summaryUnit
 
-  const total = selectedStudy.summary.summaryTotal
+  const max = selectedStudy.summary.summaryMax
 
   const colorScheme = [
     `bg-[#fedeb4]`,
@@ -32,7 +32,7 @@ export const ColorLegend: React.FC = () => {
                 )}
               ></div>
               <div className="flex justify-center">
-                {largeNumberDisplay(total / (colorScheme.length - idx), 0)}
+                {largeNumberDisplay(max / (colorScheme.length - idx), 0)}
               </div>
             </span>
           )


### PR DESCRIPTION
From Ricardo's email:

> one thing that would important to change when possible is the scale in the dashboard. Now the scale/leged considers the Sum of the values as the maximum and not the maximum value per se. with this the legend is completely out of scale and scope.

This PR changes the legend so that the values are based on the _maximum_ value, not the _total_ value.